### PR TITLE
don't round devicePixelRatio

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,8 +262,7 @@ window.addEventListener('resize', function() {
 });
 
 // pixel ratio
-var pxr = window.devicePixelRatio || window.screen.availWidth / document.documentElement.clientWidth;
-pxr=pxr.toFixed(2);
+var pxr = window.devicePixelRatio || (window.screen.availWidth / document.documentElement.clientWidth).toFixed(2);
 document.getElementById('jsratio').innerHTML = 'JS pixel-ratio : <em>'+pxr+'</em>';
 
 // user agent


### PR DESCRIPTION
I was seeing "2.63" for my nexus 5 which has a dPR of `2.625`